### PR TITLE
Add EventInfo

### DIFF
--- a/Assets/Scripts/Events/Event.cs
+++ b/Assets/Scripts/Events/Event.cs
@@ -7,12 +7,15 @@ using UnityEngine.Events;
 public class Event : ScriptableObject
 {
     UnityEvent e;
+    public EventInfo eventInfo;
+
     public void Subscribe(UnityAction action)
     {
         e.AddListener(action);
     }
-    public void Invoke()
+    public void Invoke(EventInfo eventInfo = null)
     {
+        this.eventInfo = eventInfo;
         e.Invoke();
     }
 

--- a/Assets/Scripts/Events/EventInfo.cs
+++ b/Assets/Scripts/Events/EventInfo.cs
@@ -1,0 +1,13 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class EventInfo
+{
+    public GameObject gameObject;
+
+    public EventInfo(GameObject gameObject = null)
+    {
+        this.gameObject = gameObject;
+    }
+}


### PR DESCRIPTION
EventInfo can be passed to Event.Invoke.

EventInfo currently only contains GameObject gameObject.