### PR TITLE
Events

### DIFF
--- a/Assets/Scripts/Events/Event.cs
+++ b/Assets/Scripts/Events/Event.cs
@@ -18,6 +18,16 @@ public class Event : ScriptableObject
         this.eventInfo = eventInfo;
         e.Invoke();
     }
+    public void Invoke(EventInfoMono eventInfoMono = null)
+    {
+        eventInfo = eventInfoMono.eventInfo;
+        e.Invoke();
+    }
+    public void Invoke(EventInfoSO eventInfoSO = null)
+    {
+        eventInfo = eventInfoSO.eventInfo;
+        e.Invoke();
+    }
 
     public void Unsubscribe(UnityAction action)
     {

--- a/Assets/Scripts/Events/EventInfoMono.cs
+++ b/Assets/Scripts/Events/EventInfoMono.cs
@@ -2,8 +2,7 @@ using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 
-[System.Serializable]
-public class EventInfo
+public class EventInfoMono : MonoBehaviour
 {
-    public GameObject gameObject;
+    public EventInfo eventInfo;
 }

--- a/Assets/Scripts/Events/EventInfoSO.cs
+++ b/Assets/Scripts/Events/EventInfoSO.cs
@@ -1,0 +1,9 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+[CreateAssetMenu(fileName = "Event info", menuName = "Event/Event info")]
+public class EventInfoSO : ScriptableObject
+{
+    public EventInfo eventInfo;
+}


### PR DESCRIPTION
EventInfo has been reverted to a regular c# class so instances can be created in code.

Added EventInfoMono. This contains EventInfo and allows ease of creating and assigning EventInfo in the Inspector.

Added EventInfoSO. This contains EventInfo and allows creation of persistent, cross-scene EventInfo that can be easily assigned in the inspector.