### PR TITLE
Update

### DIFF
--- a/Assets/Editor/BoardManagerEditor.cs
+++ b/Assets/Editor/BoardManagerEditor.cs
@@ -6,11 +6,15 @@ public class BoardManagerEditor : Editor
 {
     public SerializedProperty tilePercentages;
     public SerializedProperty tilesParent;
+    public SerializedProperty widthInTiles;
+    public SerializedProperty heightInTiles;
 
     void OnEnable()
     {
         tilePercentages = serializedObject.FindProperty("tilePercentages");
         tilesParent = serializedObject.FindProperty("tilesParent");
+        widthInTiles = serializedObject.FindProperty("widthInTiles");
+        heightInTiles = serializedObject.FindProperty("heightInTiles");
     }
 
     public override void OnInspectorGUI()
@@ -18,6 +22,8 @@ public class BoardManagerEditor : Editor
         serializedObject.Update();
 
         EditorGUILayout.PropertyField(tilesParent);
+        EditorGUILayout.PropertyField(widthInTiles);
+        EditorGUILayout.PropertyField(heightInTiles);
         EditorGUILayout.LabelField("Total percent: " + GetTotalPercent().ToString());
 
         DisplayTilesAndPercentages();

--- a/Assets/Scripts/Board and tiles/BoardManager.cs
+++ b/Assets/Scripts/Board and tiles/BoardManager.cs
@@ -5,9 +5,9 @@ using Zenject;
 
 public class BoardManager : MonoBehaviour
 {
-    public static int boardTileWidth = 8;
-    public static int boardTileHeight = 8;
-    public static Tile[,] tiles;
+    public int widthInTiles = 8;
+    public int heightInTiles = 8;
+    public Tile[,] Tiles { get; private set; }
 
     [Inject] TileBorders tileBorders;
 
@@ -38,7 +38,7 @@ public class BoardManager : MonoBehaviour
     /// </returns>
     List<TileTypeValue> GetTileAmounts()
     {
-        int totalTiles = boardTileWidth * boardTileHeight;
+        int totalTiles = widthInTiles * heightInTiles;
         int remainingTiles = totalTiles;
 
         List<TileTypeValue> tileAmounts = new();
@@ -94,18 +94,18 @@ public class BoardManager : MonoBehaviour
     /// </summary>
     public void GenerateBoard()
     {
-        tiles = new Tile[boardTileWidth, boardTileHeight];
+        Tiles = new Tile[widthInTiles, heightInTiles];
         List<TileTypeValue> tileAmounts = GetTileAmounts();
         int remainingTiles = GetTotalTileTypeValue(tileAmounts);
 
-        if (remainingTiles < boardTileWidth * boardTileHeight)
+        if (remainingTiles < widthInTiles * heightInTiles)
         {
             throw new Exception("Not enough tiles assigned to fill the board");
         }
 
-        for (int i = 0; i < boardTileWidth; i++)
+        for (int i = 0; i < widthInTiles; i++)
         {
-            for (int j = 0; j < boardTileHeight; j++)
+            for (int j = 0; j < heightInTiles; j++)
             {
                 int tileNumber = UnityEngine.Random.Range(0, remainingTiles);
                 int tileTypeIndex = CumulativeValueToIndex(tileAmounts, tileNumber);
@@ -116,7 +116,7 @@ public class BoardManager : MonoBehaviour
                 tile.transform.SetParent(tilesParent);
                 tile.transform.position = new Vector3(i * Tile.Width, 0, j * Tile.Height);
 
-                tiles[i, j] = tile;
+                Tiles[i, j] = tile;
                 tile.boardPosition = new Vector2Int(i, j);
 
                 tileAmounts[tileTypeIndex].value--;
@@ -134,5 +134,11 @@ public class BoardManager : MonoBehaviour
     public void RemoveAllTileBorders()
     {
         tileBorders.RemoveAllTileBorders();
+    }
+
+    public Tile TryGetTileAtPosition(int x, int y)
+    {
+        if (x < 0 || x > widthInTiles || y < 0 || y > heightInTiles) return null;
+        return Tiles[x, y];
     }
 }

--- a/Assets/Scripts/Board and tiles/TileBorders.cs
+++ b/Assets/Scripts/Board and tiles/TileBorders.cs
@@ -11,6 +11,8 @@ public class TileBorders : IInitializable
 
     Gradient borderGradient;
 
+    [Inject] BoardManager boardManager;
+
     enum Side
     {
         None,
@@ -87,10 +89,10 @@ public class TileBorders : IInitializable
     public void DisplayBorderAroundTiles(Tile bottomLeftTile, int width, int height, Gradient gradient)
     {
         if (bottomLeftTile == null) throw new ArgumentNullException("bottomLeftTile cannot be null");
-        if (bottomLeftTile.boardPosition.x < 0 || bottomLeftTile.boardPosition.x >= BoardManager.boardTileWidth ||
-            bottomLeftTile.boardPosition.y < 0 || bottomLeftTile.boardPosition.y >= BoardManager.boardTileHeight)
+        if (bottomLeftTile.boardPosition.x < 0 || bottomLeftTile.boardPosition.x >= boardManager.widthInTiles ||
+            bottomLeftTile.boardPosition.y < 0 || bottomLeftTile.boardPosition.y >= boardManager.heightInTiles)
         {
-            throw new ArgumentOutOfRangeException("bottomLeftTile.boardPosition must be in range of BoardManager.tiles");
+            throw new ArgumentOutOfRangeException("bottomLeftTile.boardPosition must be in range of boardManager.tiles");
         }
         if (width < 1 || height < 1) throw new ArgumentOutOfRangeException("width and height must be greater than 0");
 
@@ -101,26 +103,26 @@ public class TileBorders : IInitializable
         for (int i = 0; i < width; i++)
         {
             posX = i + bottomLeftTile.boardPosition.x;
-            if (posX >= BoardManager.boardTileWidth) break;
+            if (posX >= boardManager.widthInTiles) break;
 
             if (i == 0) sides[0] = Side.Left;
-            else if (i == width - 1 || posX == BoardManager.boardTileWidth - 1) sides[0] = Side.Right;
+            else if (i == width - 1 || posX == boardManager.widthInTiles - 1) sides[0] = Side.Right;
             else sides[0] = Side.None;
 
             for (int j = 0; j < height; j++)
             {
                 posY = j + bottomLeftTile.boardPosition.y;
-                if (posY >= BoardManager.boardTileHeight) break;
+                if (posY >= boardManager.heightInTiles) break;
 
                 if (j == 0) sides[1] = Side.Bottom;
-                else if (j == height - 1 || posY == BoardManager.boardTileHeight - 1) sides[1] = Side.Top;
+                else if (j == height - 1 || posY == boardManager.heightInTiles - 1) sides[1] = Side.Top;
                 else sides[1] = Side.None;
 
                 for (int k = 0; k < 2; k++)
                 {
                     if (sides[k] != Side.None)
                     {
-                        DisplayBorder(new BorderInfo(BoardManager.tiles[posX, posY], sides[k]));
+                        DisplayBorder(new BorderInfo(boardManager.Tiles[posX, posY], sides[k]));
                     }
                 }
             }


### PR DESCRIPTION
Changed the BoardManager.boardTileWidth and .boardTileHeight to .widthInTiles and .heightInTiles respectively, also made them non-static so they can be drawn in the Inspector and can be access cross-scene with Zenject.

Made BoardManager.tiles non-static and a property so it can be accessed cross-scene with Zenject and can't be changed outside of the class.

Added a method to BoardManager to try and get a tile, returns null if the given position is out of range. This just removes the need for classes to check themselves, avoiding repeated code.